### PR TITLE
Manual edit to Simon's Star

### DIFF
--- a/Manual/Simon's Star.html
+++ b/Manual/Simon's Star.html
@@ -47,11 +47,11 @@
                         <th class='translatable'>Stage 1</th>
                         <td class='translatable'>
                           <ul>
-                            <li class='translatable'>If red flashed, press <em>green + 2</em>.</li>
-                            <li class='translatable'>Otherwise, if blue flashed, press <em>yellow - #</em>.</li>
-                            <li class='translatable'>Otherwise, if yellow flashed, press <em>purple + #</em>.</li>
-                            <li class='translatable'>Otherwise, if green flashed, press <em>red - 1</em>.</li>
-                            <li class='translatable'>Otherwise, press <em>blue - 2</em>.</li>
+                            <li class='translatable'>If red flashed, press green + 2.</li>
+                            <li class='translatable'>Otherwise, if blue flashed, press yellow - #.</li>
+                            <li class='translatable'>Otherwise, if yellow flashed, press purple + #.</li>
+                            <li class='translatable'>Otherwise, if green flashed, press red - 1.</li>
+                            <li class='translatable'>Otherwise, press blue - 2.</li>
                         </ul>
                       </td>
                     </tr>
@@ -59,11 +59,11 @@
                         <th class='translatable'>Stage 2</th>
                         <td class='translatable'>
                           <ul>
-                            <li class='translatable'>If green flashed and the colour that flashed at stage 1 was not purple or red, press <em>blue - #</em>.</li>
-                            <li class='translatable'>Otherwise, if red flashed and the colour that was pressed at stage 1 was not green or blue, press <em>yellow + 3</em>.</li>
+                            <li class='translatable'>If green flashed and the colour that flashed at stage 1 was not purple or red, press blue - #.</li>
+                            <li class='translatable'>Otherwise, if red flashed and the colour that was pressed at stage 1 was not green or blue, press yellow + 3.</li>
                             <li class='translatable'>Otherwise, if blue flashed and the colour that was pressed at stage 1 was purple or yellow, press green.</li>
-                            <li class='translatable'>Otherwise, if yellow flashed and the colour that flashed at stage 1 was not red, press <em>red - 2</em>.</li>
-                            <li class='translatable'>Otherwise, if purple flashed and the colour that flashed at stage 1 was green or red, press <em>purple + #</em>.</li>
+                            <li class='translatable'>Otherwise, if yellow flashed and the colour that flashed at stage 1 was not red, press red - 2.</li>
+                            <li class='translatable'>Otherwise, if purple flashed and the colour that flashed at stage 1 was green or red, press purple + #.</li>
                             <li class='translatable'>Otherwise, press the colour that flashed at stage 1.</li>
                         </ul>
                       </td>
@@ -92,10 +92,10 @@
                       <th class='translatable'>Stage 3</th>
                       <td class='translatable'>
                         <ul>
-                          <li class='translatable'>If three unique colours have flashed, press <em>yellow - #</em>.</li>
-                          <li class='translatable'>Otherwise, if two unique colours have been pressed,<br>press <em>blue + 2</em>.</li>
-                          <li class='translatable'>Otherwise, if neither green or purple have been pressed, <br>press <em>red + #</em>.</li>
-                          <li class='translatable'>Otherwise, if blue or red flashed, press <em>purple - 1</em>.</li>
+                          <li class='translatable'>If three unique colours have flashed, press yellow - #.</li>
+                          <li class='translatable'>Otherwise, if two unique colours have been pressed,<br>press blue + 2.</li>
+                          <li class='translatable'>Otherwise, if neither green or purple have been pressed, <br>press red + #.</li>
+                          <li class='translatable'>Otherwise, if blue or red flashed, press purple - 1.</li>
                           <li class='translatable'>Otherwise, press the colour that was pressed at stage 1.</li>
                       </ul>
                     </td>
@@ -104,10 +104,10 @@
                       <th class='translatable'>Stage 4</th>
                       <td class='translatable'>
                         <ul>
-                          <li class='translatable'>If the colour that flashed at <em>stage 3 + #</em> has been pressed, press the colour that was pressed at stage 2.</li>
-                          <li class='translatable'>Otherwise, if the colour that flashed at <em>stage 4 - 2</em> has not been pressed, press the colour that flashed at <em>stage 3 - #</em>.</li>
-                          <li class='translatable'>Otherwise, if the colour that was pressed at <em>stage 2 - #</em> has flashed, press the colour that flashed at stage 1.</li>
-                          <li class='translatable'>Otherwise, if the colour that was pressed at <em>stage 1 + 2</em> has not been pressed, press the colour that was pressed at <em>stage 3 + #</em>.</li>
+                          <li class='translatable'>If <em>the colour that flashed at stage 3</em> + # has been pressed, press the colour that was pressed at stage 2.</li>
+                          <li class='translatable'>Otherwise, if <em>the colour that flashed at stage 4</em> - 2 has not been pressed, press <em>the colour that flashed at stage 3</em> - #.</li>
+                          <li class='translatable'>Otherwise, if <em>the colour that was pressed at stage 2</em> - # has flashed, press the colour that flashed at stage 1.</li>
+                          <li class='translatable'>Otherwise, if <em>the colour that was pressed at stage 1</em> + 2 has not been pressed, press <em>the colour that was pressed at stage 3</em> + #.</li>
                           <li class='translatable'>Otherwise, press the colour that flashed at stage 2</li>
                       </ul>
                     </td>
@@ -119,10 +119,10 @@
                           <li class='translatable'>If all five colours have flashed, press green.</li>
                           <li class='translatable'>Otherwise, if purple has not been pressed, press red.</li>
                           <li class='translatable'>Otherwise, if yellow has not flashed, press blue.</li>
-                          <li class='translatable'>Otherwise, if <em>red - #</em> has not been pressed, press purple.</li>
-                          <li class='translatable'>Otherwise, if <em>blue + #</em> has not flashed, press yellow.</li>
-                          <li class='translatable'>Otherwise, if green has flashed and been pressed, press <em>red + #</em>.</li>
-                          <li class='translatable'>Otherwise, press <em>blue - #</em>.</li>
+                          <li class='translatable'>Otherwise, if red - # has not been pressed, press purple.</li>
+                          <li class='translatable'>Otherwise, if blue + # has not flashed, press yellow.</li>
+                          <li class='translatable'>Otherwise, if green has flashed and been pressed, press red + #.</li>
+                          <li class='translatable'>Otherwise, press blue - #.</li>
                       </ul>
                     </td>
                   </tr>


### PR DESCRIPTION
Strips away many em tags except where necessary (in yabba's opinion) to denote stage 4 variables clearly.